### PR TITLE
adds support for the publish variable 

### DIFF
--- a/examples/s3-publish/README.md
+++ b/examples/s3-publish/README.md
@@ -1,0 +1,3 @@
+## examples/s3-publish
+
+Basic example which creates a Lambda function from s3 bucket with logging privileges using publish to increment the version number.

--- a/examples/s3-publish/example.tf
+++ b/examples/s3-publish/example.tf
@@ -1,0 +1,52 @@
+provider "aws" {
+  region = "eu-west-1"
+}
+
+module "lambda" {
+  source = "../../"
+
+  name_prefix = "example"
+  s3_bucket   = "telia-oss"
+  s3_key      = "hello-world/helloworld.zip"
+  policy      = "${data.aws_iam_policy_document.lambda.json}"
+  runtime     = "python3.6"
+  handler     = "helloworld.handler"
+  publish     = "true"
+
+  environment {
+    TEST = "TEST VALUE"
+  }
+
+  tags {
+    environment = "prod"
+    terraform   = "True"
+  }
+}
+
+data "aws_iam_policy_document" "lambda" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+output "lambda_arn" {
+  value = "${module.lambda.arn}"
+}
+
+output "lambda_invoke_arn" {
+  value = "${module.lambda.invoke_arn}"
+}
+
+output "lambda_qualified_arn" {
+  value = "${module.lambda.qualified_arn}"
+}

--- a/main.tf
+++ b/main.tf
@@ -13,6 +13,7 @@ resource "aws_lambda_function" "main" {
   timeout                        = "${var.timeout}"
   role                           = "${aws_iam_role.main.arn}"
   reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
+  publish                        = "${var.publish}"
 
   environment {
     variables = "${var.environment}"
@@ -33,6 +34,7 @@ resource "aws_lambda_function" "vpc" {
   timeout                        = "${var.timeout}"
   role                           = "${aws_iam_role.main.arn}"
   reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
+  publish                        = "${var.publish}"
 
   vpc_config {
     subnet_ids         = ["${var.subnet_ids}"]
@@ -59,6 +61,7 @@ resource "aws_lambda_function" "main_s3" {
   timeout                        = "${var.timeout}"
   role                           = "${aws_iam_role.main.arn}"
   reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
+  publish                        = "${var.publish}"
 
   environment {
     variables = "${var.environment}"
@@ -85,6 +88,7 @@ resource "aws_lambda_function" "vpc_s3" {
   timeout                        = "${var.timeout}"
   role                           = "${aws_iam_role.main.arn}"
   reserved_concurrent_executions = "${var.reserved_concurrent_executions}"
+  publish                        = "${var.publish}"
 
   vpc_config {
     subnet_ids         = ["${var.subnet_ids}"]

--- a/outputs.tf
+++ b/outputs.tf
@@ -30,3 +30,8 @@ output "invoke_arn" {
   description = " The ARN to be used for invoking Lambda Function from API Gateway - to be used in aws_api_gateway_integration uri."
   value       = "${element(concat(aws_lambda_function.main.*.invoke_arn, aws_lambda_function.vpc.*.invoke_arn, aws_lambda_function.main_s3.*.invoke_arn, aws_lambda_function.vpc_s3.*.invoke_arn,), 0)}"
 }
+
+output "qualified_arn" {
+  description = " The Amazon Resource Name (ARN) identifying your Lambda Function Version (if versioning is enabled via publish = true)."
+  value       = "${element(concat(aws_lambda_function.main.*.qualified_arn, aws_lambda_function.vpc.*.qualified_arn, aws_lambda_function.main_s3.*.qualified_arn, aws_lambda_function.vpc_s3.*.qualified_arn,), 0)}"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -89,3 +89,8 @@ variable "reserved_concurrent_executions" {
   description = "The amount of reserved concurrent executions for this lambda function. A value of 0 disables lambda from being triggered and -1 removes any concurrency limitations. Defaults to Unreserved Concurrency Limits -1"
   default     = -1
 }
+
+variable "publish" {
+  description = "Whether to publish creation/change as new Lambda Function Version. Defaults to false."
+  default     = "false"
+}


### PR DESCRIPTION
Adds support for the publish variable which is used to version lambda functions. When versioning is set to true the qualifying_arn output shows which version number the lambda function received.
