### PR TITLE
Add IAM trust relationship for Lambda@Edge

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,7 +52,7 @@ data "aws_iam_policy_document" "assume" {
 
     principals {
       type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
+      identifiers = ["edgelambda.amazonaws.com", "lambda.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
For Lambda@Edge, another entity should be trusted for role assumption:
https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/lambda-edge-permissions.html#lambda-edge-permissions-function-execution