### PR TITLE
Omit environment block when empty

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,11 @@ resource "aws_lambda_function" "main" {
     security_group_ids = aws_security_group.vpc[*].id
   }
 
-  environment {
-    variables = var.environment
+  dynamic "environment" {
+    for_each = length(var.environment) > 0 ? [1] : []
+    content {
+      variables = var.environment
+    }
   }
 
   layers = var.layers


### PR DESCRIPTION
This addresses https://github.com/telia-oss/terraform-aws-lambda/issues/27

The provider does not permit an empty `environment` block, nor can environment variables be defined for Lambda@Edge