### PR TITLE
Upgrade to v4 AWS provider

### DIFF
--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,7 +9,7 @@ module "lambda" {
   filename         = "${path.module}/lambda.zip"
   source_code_hash = data.archive_file.lambda.output_base64sha256
   policy           = data.aws_iam_policy_document.lambda.json
-  runtime          = "python3.10"
+  runtime          = "python3.9"
   handler          = "lambda.handler"
 
   environment = {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -1,5 +1,4 @@
 provider "aws" {
-  #version = ">= 3.0"  ##This is moved to the required providers block on TF 0.14
   region = var.region
 }
 

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -9,7 +9,7 @@ module "lambda" {
   filename         = "${path.module}/lambda.zip"
   source_code_hash = data.archive_file.lambda.output_base64sha256
   policy           = data.aws_iam_policy_document.lambda.json
-  runtime          = "python3.9"
+  runtime          = "python3.10"
   handler          = "lambda.handler"
 
   environment = {

--- a/examples/basic/main.tf
+++ b/examples/basic/main.tf
@@ -10,7 +10,7 @@ module "lambda" {
   filename         = "${path.module}/lambda.zip"
   source_code_hash = data.archive_file.lambda.output_base64sha256
   policy           = data.aws_iam_policy_document.lambda.json
-  runtime          = "python3.6"
+  runtime          = "python3.9"
   handler          = "lambda.handler"
 
   environment = {

--- a/examples/basic/versions.tf
+++ b/examples/basic/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -52,7 +52,7 @@ module "lambda" {
   s3_key            = aws_s3_object.lambda.id
   s3_object_version = aws_s3_object.lambda.version_id
   policy            = data.aws_iam_policy_document.lambda.json
-  runtime           = "python3.9"
+  runtime           = "python3.10"
   handler           = "lambda.handler"
   vpc_id            = data.aws_vpc.main.id
   subnet_ids        = data.aws_subnets.main.ids

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -42,7 +42,7 @@ module "lambda" {
   s3_key            = aws_s3_bucket_object.lambda.id
   s3_object_version = aws_s3_bucket_object.lambda.version_id
   policy            = data.aws_iam_policy_document.lambda.json
-  runtime           = "python3.6"
+  runtime           = "python3.9"
   handler           = "lambda.handler"
   vpc_id            = data.aws_vpc.main.id
   subnet_ids        = data.aws_subnet_ids.main.ids

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -52,7 +52,7 @@ module "lambda" {
   s3_key            = aws_s3_object.lambda.id
   s3_object_version = aws_s3_object.lambda.version_id
   policy            = data.aws_iam_policy_document.lambda.json
-  runtime           = "python3.10"
+  runtime           = "python3.9"
   handler           = "lambda.handler"
   vpc_id            = data.aws_vpc.main.id
   subnet_ids        = data.aws_subnets.main.ids

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
     archive = {
       source  = "hashicorp/archive"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 3.0"
+      version = "~> 4.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 3.0, < 5.0"
     }
   }
 }


### PR DESCRIPTION
I have tested `examples/complete` on the current `master` and then upgrading with the changes in this PR, and the only changes were to the S3 bucket in the example (not a part of the module). I.e. it should be safe to upgrade the module directly to V4.

This would be a _minor_ release since the provider constraint still covers the 3.0 versions.